### PR TITLE
Guard analyze mutation to prevent duplicate TanStack Query requests

### DIFF
--- a/frontend/src/app/analyze/analyzing/page.tsx
+++ b/frontend/src/app/analyze/analyzing/page.tsx
@@ -1,17 +1,17 @@
 "use client";
-import { useEffect, useRef } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
 import { useRouter } from "next/navigation";
-import { useSetAtom, useAtomValue } from "jotai";
+import { useEffect, useRef } from "react";
+import { useAnalyzeCompany } from "@/hooks/useAnalyzeCompany";
 import { analysisResultAtom } from "@/stores/analysisResultAtom";
 import { inputInfoAtom } from "@/stores/inputInfoAtom";
-import { useAnalyzeCompany } from "@/hooks/useAnalyzeCompany";
 
 const AnalyzingPage = () => {
   const router = useRouter();
   const setResult = useSetAtom(analysisResultAtom);
   const hasRequest = useRef(false);
   const inputInfo = useAtomValue(inputInfoAtom);
-  const {mutate,isPending,isError,error} = useAnalyzeCompany();
+  const { mutate } = useAnalyzeCompany();
 
   useEffect(() => {
     if (hasRequest.current) return;
@@ -19,9 +19,12 @@ const AnalyzingPage = () => {
     // 入力情報がない場合はフォームページにリダイレクト
     if (!inputInfo.industry || !inputInfo.job_text) {
       router.push("/analyze");
-      window.alert('入力情報がないため、入力ページにリダイレクトしました')
+      window.alert("入力情報がないため、入力ページにリダイレクトしました");
       return;
     }
+
+    hasRequest.current = true;
+
     mutate(
       { industry: inputInfo.industry, job_text: inputInfo.job_text },
       {
@@ -35,11 +38,11 @@ const AnalyzingPage = () => {
         },
         onError: (err) => {
           router.push("/analyze?error=unexpected_error");
-          window.alert('分析中にエラーが発生しました: ' + err.message);
+          window.alert(`分析中にエラーが発生しました: ${err.message}`);
         },
-      }
+      },
     );
-  }, []);
+  }, [inputInfo.industry, inputInfo.job_text, mutate, router, setResult]);
 
   return (
     <div className="flex flex-col items-center justify-center h-screen">


### PR DESCRIPTION
### Motivation
- Prevent duplicate API requests when running the analyze flow (React Strict Mode / double effects) by ensuring the TanStack Query mutation is only triggered once. 
- Clean up unused mutation state and make error messages and side-effect dependencies deterministic for stable routing after analysis.

### Description
- Use the existing `useAnalyzeCompany` mutation and remove unused mutation state variables, keeping only `mutate` in `AnalyzingPage`.
- Add a strict-mode-safe guard `hasRequest.current = true` before calling `mutate` to prevent duplicate requests.
- Convert concatenated alert messages to template literals and make `useEffect` dependency list explicit: `[inputInfo.industry, inputInfo.job_text, mutate, router, setResult]`.
- Reorder imports in `frontend/src/app/analyze/analyzing/page.tsx` to satisfy formatting/linting rules.

### Testing
- Ran `npx biome check src/app/analyze/analyzing/page.tsx` which completed with no reported errors for that file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1a7f42c4c83228f85b2e312a51efd)